### PR TITLE
bump to 0.2.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,10 +23,10 @@ description = "QuPath extension to use Warpy"
 
 group = "ch.epfl.biop"
 // artifact = "qupath-extension-warpy"
-version = "0.2.3-SNAPSHOT"
+version = "0.2.4-SNAPSHOT"
 
 dependencies {
-    val qupathVersion = "0.3.0" // For now
+    val qupathVersion = "0.4.3" // For now
 
     //shadow("io.github.qupath:qupath-gui-fx:$qupathVersion")
     //shadow("org.slf4j:slf4j-api:1.7.30")

--- a/src/main/java/qupath/ext/imagecombinerwarpy/gui/AffineTransformInterpolationImageServer.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/gui/AffineTransformInterpolationImageServer.java
@@ -274,7 +274,7 @@ public class AffineTransformInterpolationImageServer extends TransformingImageSe
 	
 	
 	@Override
-	public BufferedImage readBufferedImage(final RegionRequest request) throws IOException {
+	public BufferedImage readRegion(RegionRequest request) throws IOException {
 
 		double downsample = request.getDownsample();
 		
@@ -311,7 +311,7 @@ public class AffineTransformInterpolationImageServer extends TransformingImageSe
 				request.getT()
 				);
 			
-		BufferedImage img = getWrappedServer().readBufferedImage(requestTR);
+		BufferedImage img = getWrappedServer().readRegion(requestTR);
 		if (img == null)
 			return img;
 		

--- a/src/main/java/qupath/ext/imagecombinerwarpy/gui/ImageCombinerWarpyPane.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/gui/ImageCombinerWarpyPane.java
@@ -1444,8 +1444,8 @@ public class ImageCombinerWarpyPane {
 			downsample = requestedPixelSizeMicrons / calBase.getAveragedPixelSizeMicrons();			
 		}
 
-		BufferedImage imgBase = serverBase.readBufferedImage(RegionRequest.createInstance(serverBase.getPath(), downsample, 0, 0, serverBase.getWidth(), serverBase.getHeight()));
-		BufferedImage imgOverlay = serverOverlay.readBufferedImage(RegionRequest.createInstance(serverOverlay.getPath(), downsample, 0, 0, serverOverlay.getWidth(), serverOverlay.getHeight()));
+		BufferedImage imgBase = serverBase.readRegion(RegionRequest.createInstance(serverBase.getPath(), downsample, 0, 0, serverBase.getWidth(), serverBase.getHeight()));
+		BufferedImage imgOverlay = serverOverlay.readRegion(RegionRequest.createInstance(serverOverlay.getPath(), downsample, 0, 0, serverOverlay.getWidth(), serverOverlay.getHeight()));
 		
 		//::dip
 		if (viewerTmp != null)

--- a/src/main/java/qupath/ext/imagecombinerwarpy/gui/RealTransformImageServer.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/gui/RealTransformImageServer.java
@@ -249,7 +249,7 @@ public class RealTransformImageServer extends TransformingImageServer<BufferedIm
 	
 	
 	@Override
-	public BufferedImage readBufferedImage(final RegionRequest request) throws IOException {
+	public BufferedImage readRegion(RegionRequest request) throws IOException {
 
 		RealTransform transform2 = realtransform.copy();
 
@@ -293,7 +293,7 @@ public class RealTransformImageServer extends TransformingImageServer<BufferedIm
 				);
 		
 		// Source
-		BufferedImage img = getWrappedServer().readBufferedImage(requestTR);
+		BufferedImage img = getWrappedServer().readRegion(requestTR);
 		if (img == null)
 			return img;
 


### PR DESCRIPTION
Several users encountered a problem when using ImageCombinerWarpy in QuPath version 0.4.x.

Transformatios were not applied.


https://forum.image.sc/t/issue-with-warpy-and-mac-osx/79421
https://forum.image.sc/t/unsuccessful-registration-using-warpy-image-combiner-in-qupath/79681/4
https://forum.image.sc/t/imagecombinerwarpy-overlaying-registered-images-in-qupath/61804/20

Reason: 

petebankhead:
"Specifically, ImageServer.readBufferedImage became ImageServer.readRegion – but I tried to maintain compatibility of old plugins by using a default method that falls back to readBufferedImage if needed."

see:
https://github.com/qupath/qupath/pull/1072