### PR TITLE
Prevent int overflow in AffineTransformInterpolationImageServer

### DIFF
--- a/src/main/java/qupath/ext/imagecombinerwarpy/gui/AffineTransformInterpolationImageServer.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/gui/AffineTransformInterpolationImageServer.java
@@ -110,7 +110,7 @@ public class AffineTransformInterpolationImageServer extends TransformingImageSe
 		
 		transform.transform(edges, 0, edgesTR, 0, 2);
 		
-		double lOrig = Math.sqrt(server.getWidth()*server.getWidth() + server.getHeight()*server.getHeight());
+		double lOrig = Math.sqrt((double)server.getWidth()*(double)server.getWidth() + (double)server.getHeight()*(double)server.getHeight());
 		double lRT = Math.sqrt((edgesTR[2]-edgesTR[0])*(edgesTR[2]-edgesTR[0]) 
 								+ (edgesTR[3]-edgesTR[1])*(edgesTR[3]-edgesTR[1]));
 		double scale = lRT / lOrig;


### PR DESCRIPTION
similar to https://github.com/BIOP/qupath-extension-warpy/issues/11
see [commit 891c718](https://github.com/BIOP/qupath-extension-warpy/commit/891c7182e530fb29106adb5dade7410b4a8a14c2)