### PR TITLE
Update for QuPath 0.6.0-rc3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext.qupathVersion = gradle.ext.qupathVersion
 
 ext.moduleName = "qupath.ext.warpy"
 description = "QuPath extension to use Warpy"
-version = "0.3.2-SNAPSHOT"
+version = "0.4.0"
 
 dependencies {
     implementation "io.github.qupath:qupath-gui-fx:${qupathVersion}"
@@ -56,7 +56,7 @@ tasks.register("copyDependencies", Copy) {
  */
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
     if (project.properties['sources'])
         withSourcesJar()

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext.qupathVersion = gradle.ext.qupathVersion
 
 ext.moduleName = "qupath.ext.warpy"
 description = "QuPath extension to use Warpy"
-version = "0.4.0"
+version = "0.4.0-SNAPSHOT"
 
 dependencies {
     implementation "io.github.qupath:qupath-gui-fx:${qupathVersion}"

--- a/src/main/java/qupath/ext/imagecombinerwarpy/gui/AffineTransformInterpolationImageServerBuilder.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/gui/AffineTransformInterpolationImageServerBuilder.java
@@ -43,10 +43,6 @@ public class AffineTransformInterpolationImageServerBuilder implements ServerBui
 		return new AffineTransformInterpolationImageServer(builder.build(), transforminterpolation);
 	}
 
-	protected ImageServerMetadata getMetadata() {
-		return metadata;
-	}
-
 	@Override
 	public ImageServer<BufferedImage> build() throws Exception {
 		var server = buildOriginal();
@@ -67,7 +63,7 @@ public class AffineTransformInterpolationImageServerBuilder implements ServerBui
 		ServerBuilder<BufferedImage> newBuilder = builder.updateURIs(updateMap);
 		if (newBuilder == builder)
 			return this;
-		return new AffineTransformInterpolationImageServerBuilder(getMetadata(), newBuilder, transforminterpolation);
+		return new AffineTransformInterpolationImageServerBuilder(getMetadata().get(), newBuilder, transforminterpolation);
 	}
 
 

--- a/src/main/java/qupath/ext/imagecombinerwarpy/gui/RealTransformImageServerBuilder.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/gui/RealTransformImageServerBuilder.java
@@ -45,9 +45,6 @@ public class RealTransformImageServerBuilder implements ServerBuilder<BufferedIm
 		return new RealTransformImageServer(builder.build(), realtransforminterpolation, interpolation);
 	}
 
-	protected ImageServerMetadata getMetadata() {
-		return metadata;
-	}
 
 	@Override
 	public ImageServer<BufferedImage> build() throws Exception {
@@ -69,7 +66,7 @@ public class RealTransformImageServerBuilder implements ServerBuilder<BufferedIm
 		ServerBuilder<BufferedImage> newBuilder = builder.updateURIs(updateMap);
 		if (newBuilder == builder)
 			return this;
-		return new RealTransformImageServerBuilder(getMetadata(), newBuilder, realtransforminterpolation);
+		return new RealTransformImageServerBuilder(getMetadata().get(), newBuilder, realtransforminterpolation);
 	}
 
 }

--- a/src/main/java/qupath/ext/warpy/Warpy.java
+++ b/src/main/java/qupath/ext/warpy/Warpy.java
@@ -415,6 +415,9 @@ public class Warpy {
             throw new Exception("Unknown PathObject class for class " + object.getClass().getSimpleName());
         }
 
+        // Return the same ID as the original object
+        transformedObject.setID(object.getID());
+        transformedObject.setName(object.getName());
         return transformedObject;
     }
 

--- a/src/main/java/qupath/ext/warpy/Warpy.java
+++ b/src/main/java/qupath/ext/warpy/Warpy.java
@@ -396,14 +396,17 @@ public class Warpy {
         } else if (object instanceof PathCellObject) {
             // Need to transform the nucleus as well
             ROI original_nuc = ((PathCellObject) object).getNucleusROI();
+            ROI transformed_nuc_roi = null;
+            if (original_nuc != null) {
 
-            Geometry nuc_geometry = original_nuc.getGeometry();
+                Geometry nuc_geometry = original_nuc.getGeometry();
 
-            GeometryTools.attemptOperation(nuc_geometry, (g) -> {
-                g.apply(transform);
-                return g;
-            });
-            ROI transformed_nuc_roi = GeometryTools.geometryToROI(nuc_geometry, original_roi.getImagePlane());
+                GeometryTools.attemptOperation(nuc_geometry, (g) -> {
+                    g.apply(transform);
+                    return g;
+                });
+                transformed_nuc_roi = GeometryTools.geometryToROI(nuc_geometry, original_roi.getImagePlane());
+            }
             transformedObject = PathObjects.createCellObject(transformed_roi, transformed_nuc_roi, object.getPathClass(), copyMeasurements ? object.getMeasurementList() : null);
 
         } else if (object instanceof PathDetectionObject) {


### PR DESCRIPTION
This extension allows for the use of Warpy with QuPath 0.6.0-rc3

It includes a bugfix which allows for InstanSeg segmentations to be transformed and transfered. 

The issue was that InstanSeg could have cells with no nucleus.