### PR TITLE
Access transforms by reflection, refactor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 qupathExtension {
     name = "qupath-extension-warpy"
     group = "qupath.ext.warpy"
-    version = "0.4.2"
+    version = "0.5.0"
     description = "Warpy - QuPath extension that supports spline transformations."
     automaticModule = "qupath.ext.warpy"
 }
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.bundles.qupath)
     implementation(libs.qupath.fxtras)
     implementation("commons-io:commons-io:2.15.0")
-    implementation("net.imglib2:imglib2-realtransform:3.1.2")
+    implementation("net.imglib2:imglib2-realtransform:4.0.4")
 }
 
 publishing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,5 +12,5 @@ plugins {
 }
 
 qupath {
-    version = "0.6.0"
+    version = "0.7.0"
 }

--- a/src/main/java/qupath/ext/imagecombinerwarpy/ImageCombinerWarpyExtension.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/ImageCombinerWarpyExtension.java
@@ -16,7 +16,7 @@ package qupath.ext.imagecombinerwarpy;
  * 
  *********************************/
 
-import net.imglib2.realtransform.RealTransformSerializer;
+import qupath.ext.imagecombinerwarpy.realtransform.RealTransformSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/BoundedRealTransform.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/BoundedRealTransform.java
@@ -1,8 +1,10 @@
-package net.imglib2.realtransform;
+package qupath.ext.imagecombinerwarpy.realtransform;
 
 import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.InvertibleRealTransform;
+import net.imglib2.realtransform.RealTransform;
 
 /**
  * RealTransform object limiting the extend of the transformation computation.

--- a/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/InvertibleWrapped2DTransformAs3D.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/InvertibleWrapped2DTransformAs3D.java
@@ -1,7 +1,8 @@
-package net.imglib2.realtransform;
+package qupath.ext.imagecombinerwarpy.realtransform;
 
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.InvertibleRealTransform;
 
 /**
  * Class copied from bigwarp_fiji repo because to avoid bringing

--- a/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/RealTransformSerializer.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/RealTransformSerializer.java
@@ -1,18 +1,33 @@
-package net.imglib2.realtransform;
+package qupath.ext.imagecombinerwarpy.realtransform;
 
-import com.google.gson.*;
-
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.List;
 import jitk.spline.ThinPlateR2LogRSplineKernelTransform;
 import net.imglib2.FinalRealInterval;
+import net.imglib2.realtransform.AbstractRealTransformSequence;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.realtransform.InvertibleRealTransform;
+import net.imglib2.realtransform.InvertibleRealTransformSequence;
+import net.imglib2.realtransform.RealTransform;
+import net.imglib2.realtransform.RealTransformSequence;
+import net.imglib2.realtransform.ThinplateSplineTransform;
 import net.imglib2.realtransform.inverse.WrappedIterativeInvertibleRealTransform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import qupath.ext.warpy.WarpyExtension;
 import qupath.ext.imagecombinerwarpy.gui.RealTransformInterpolation;
+import qupath.ext.warpy.WarpyExtension;
 import qupath.lib.io.GsonTools;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Type;
 
 /**
  * Imglib2 Real transforms adapters already used in bigdataviewer-playground
@@ -304,11 +319,16 @@ public class RealTransformSerializer {
         @Override
         public JsonElement serialize(RealTransformSequence rts, Type type, JsonSerializationContext jsonSerializationContext) {
             JsonObject obj = new JsonObject();
-            obj.addProperty("size", rts.transforms.size());
-            for (int iTransform = 0; iTransform<rts.transforms.size(); iTransform++) {
-                obj.add("realTransform_"+iTransform, jsonSerializationContext.serialize(rts.transforms.get(iTransform), RealTransform.class));
+            try {
+                List<RealTransform> transforms = getTransforms(rts);
+                obj.addProperty("size", transforms.size());
+                for (int iTransform = 0; iTransform<transforms.size(); iTransform++) {
+                    obj.add("realTransform_"+iTransform, jsonSerializationContext.serialize(transforms.get(iTransform), RealTransform.class));
+                }
+                return obj;
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
             }
-            return obj;
         }
     }
 
@@ -338,11 +358,16 @@ public class RealTransformSerializer {
         @Override
         public JsonElement serialize(InvertibleRealTransformSequence irts, Type type, JsonSerializationContext jsonSerializationContext) {
             JsonObject obj = new JsonObject();
-            obj.addProperty("size", irts.transforms.size());
-            for (int iTransform = 0; iTransform<irts.transforms.size(); iTransform++) {
-                obj.add("realTransform_"+iTransform, jsonSerializationContext.serialize(irts.transforms.get(iTransform), RealTransform.class));
+            try {
+                List<InvertibleRealTransform> transforms = getTransforms(irts);
+                obj.addProperty("size", transforms.size());
+                for (int iTransform = 0; iTransform<transforms.size(); iTransform++) {
+                    obj.add("realTransform_"+iTransform, jsonSerializationContext.serialize(transforms.get(iTransform), RealTransform.class));
+                }
+                return obj;
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
             }
-            return obj;
         }
     }
 
@@ -374,6 +399,14 @@ public class RealTransformSerializer {
             element = converted;
         }
         return element;
+    }
+
+    private static <R extends RealTransform> List<R> getTransforms(AbstractRealTransformSequence<R> sequence) throws NoSuchFieldException, IllegalAccessException {
+        Field field = AbstractRealTransformSequence.class.getDeclaredField("transforms");
+        field.setAccessible(true);
+        List<R> transforms = (List<R>)field.get(sequence);
+        logger.debug("Found {} transforms by reflection", transforms.size());
+        return transforms;
     }
 
 }

--- a/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/Wrapped2DTransformAs3D.java
+++ b/src/main/java/qupath/ext/imagecombinerwarpy/realtransform/Wrapped2DTransformAs3D.java
@@ -1,7 +1,8 @@
-package net.imglib2.realtransform;
+package qupath.ext.imagecombinerwarpy.realtransform;
 
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPositionable;
+import net.imglib2.realtransform.InvertibleRealTransform;
 
 /**
  * Class copied from bigwarp_fiji repo because to avoid bringing

--- a/src/main/java/qupath/ext/warpy/Warpy.java
+++ b/src/main/java/qupath/ext/warpy/Warpy.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject;
 import net.imglib2.RealPoint;
 import net.imglib2.realtransform.InvertibleRealTransform;
 import net.imglib2.realtransform.RealTransform;
-import net.imglib2.realtransform.RealTransformSerializer;
+import qupath.ext.imagecombinerwarpy.realtransform.RealTransformSerializer;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFilter;
 import org.locationtech.jts.geom.Geometry;


### PR DESCRIPTION
Proposed attempt to resolve https://github.com/BIOP/qupath-extension-warpy/issues/32

The main change is to use reflection to access the protected `transforms` field of `AbstractRealTransformSequence`.

This means that it's no longer necessary to put `RealTransformSerializer` in the package `net.imglib2.realtransform` - and since JPMS doesn't permit split packages, it seems better to avoids this where possible. For that reason, I moved the package - which has the advantage of causing build failures/IDE warnings whenever reflection is required, making it easier to spot this at an early stage.

The PR also updates Gradle, the version number, and the target version of QuPath - although I suspect that it should work ok with QuPath v0.6.0 anyway.